### PR TITLE
Add support for reading the 'ReferencedSegmentNumber' from the 'PerFr…

### DIFF
--- a/pydicom_seg/reader.py
+++ b/pydicom_seg/reader.py
@@ -169,8 +169,8 @@ class SegmentReader(_ReaderBase):
             for frame_idx, pffg in enumerate(dataset.PerFrameFunctionalGroupsSequence):
                 if hasattr(pffg, 'SegmentIdentificationSequence'):
                     sis = pffg.SegmentIdentificationSequence[0]
-                elif hasattr(dcm.SharedFunctionalGroupsSequence[0], 'SegmentIdentificationSequence'):
-                    sis = dcm.SharedFunctionalGroupsSequence[0].SegmentIdentificationSequence[0]
+                elif hasattr(dataset.SharedFunctionalGroupsSequence[0], 'SegmentIdentificationSequence'):
+                    sis = dataset.SharedFunctionalGroupsSequence[0].SegmentIdentificationSequence[0]
 
                 if segment_number != sis.ReferencedSegmentNumber:
                         continue

--- a/pydicom_seg/reader.py
+++ b/pydicom_seg/reader.py
@@ -167,8 +167,14 @@ class SegmentReader(_ReaderBase):
 
             # Iterate over all frames and check for referenced segment number
             for frame_idx, pffg in enumerate(dataset.PerFrameFunctionalGroupsSequence):
-                if segment_number != pffg.SegmentIdentificationSequence[0].ReferencedSegmentNumber:
-                    continue
+                if hasattr(pffg, 'SegmentIdentificationSequence'):
+                    sis = pffg.SegmentIdentificationSequence[0]
+                elif hasattr(dcm.SharedFunctionalGroupsSequence[0], 'SegmentIdentificationSequence'):
+                    sis = dcm.SharedFunctionalGroupsSequence[0].SegmentIdentificationSequence[0]
+
+                if segment_number != sis.ReferencedSegmentNumber:
+                        continue
+                        
                 frame_position = [float(x) for x in pffg.PlanePositionSequence[0].ImagePositionPatient]
                 frame_index = dummy.TransformPhysicalPointToIndex(frame_position)
                 slice_data = frame_pixel_array[frame_idx]

--- a/pydicom_seg/reader.py
+++ b/pydicom_seg/reader.py
@@ -252,14 +252,6 @@ class MultiClassReader(_ReaderBase):
         if dataset.NumberOfFrames == 1 and len(frame_pixel_array.shape) == 2:
             frame_pixel_array = np.expand_dims(frame_pixel_array, axis=0)
         
-                   
-            
-            # Iterate over all frames and check for referenced segment number
-            for frame_idx, pffg in enumerate(dataset.PerFrameFunctionalGroupsSequence):
-                sis = pffg.get('SegmentIdentificationSequence', shared_sis) # shared_sis as default value
-                if segment_number != sis[0].ReferencedSegmentNumber:
-                        continue
-        
         # get segment ID sequence for the case it is the same for all frames (e.g. only one segment) 
         shared_sis = dataset.SharedFunctionalGroupsSequence[0].get('SegmentIdentificationSequence')
         


### PR DESCRIPTION
Hello!

I propose the following modifications because the tag 'ReferencedSegmentNumber' can appear in either the 'PerFrameFunctionalGroupsSequence' or 'SharedFunctionalGroupsSequence' if it is shared for all the frames. This is stated in the DICOM format:
"Those Functional Groups that apply to all frames are included in the Shared Functional Groups Sequence (5200,9229). Functional Groups whose Attribute values may vary from frame to frame are included in the Per-frame Functional Groups Sequence (5200,9230)." A bit more detail in  http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#sect_C.7.6.16.1.1 

This change resulted from an issue that I had when trying to load data from the NSCLC Radiogenomics dataset, which had the 'ReferencedSegmentNumber' in the  'SharedFunctionalGroupsSequence'. 
(dataset in https://wiki.cancerimagingarchive.net/display/Public/NSCLC+Radiogenomics)

I am not sure though, if the MultiClassReader should have a similar modification.

jmgo