### PR TITLE
Fix externals missing in wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install pydicom-seg
 
 ### Install from source
 
-This package uses [Poetry](https://python-poetry.org/) as build system.
+This package uses [Poetry](https://python-poetry.org/) (version >= 1.0.5) as build system.
 
 ```bash
 git clone https://github.com/razorx89/pydicom-seg.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,5 @@ pytest = "^5.3.2"
 coverage = "^5.0.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.0.5"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Poetry v1.0.0 correctly packages the package source into `.tar.gz` archives, but does not include the required dcmqi sources in the `.whl` archive. In Poetry v1.0.5 it is fixed and both `.tar.gz` and `.whl` are correctly built. This PR fixes #13 by updating `pyproject.toml` to specify the correct required build system and by mentioning the version in the README.md 