### PR TITLE
Fix: Template import from single-file input metainfo.json

### DIFF
--- a/pydicom_seg/template.py
+++ b/pydicom_seg/template.py
@@ -162,8 +162,11 @@ def from_dcmqi_metainfo(metainfo: Union[dict, str]) -> pydicom.Dataset:
         else:
             dataset.__setattr__(tag_name, metainfo.get(tag_name, default_value))
 
+    if len(metainfo['segmentAttributes']) > 1:
+        raise ValueError('Only metainfo.json files written for single-file input are supported')
+
     dataset.SegmentSequence = pydicom.Sequence([
-        _create_segment_dataset(x[0]) for x in metainfo['segmentAttributes']
+        _create_segment_dataset(x) for x in metainfo['segmentAttributes'][0]
     ])
 
     return dataset

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -18,7 +18,7 @@ class TestMultiClassWriter:
             'dcmqi',
             'doc',
             'examples',
-            'seg-example_multiple_segments.json'
+            'seg-example_multiple_segments_single_input_file.json'
         ))
 
     @pytest.mark.parametrize('dtype', [np.int8, np.float32])


### PR DESCRIPTION
Resolves #14 

Currently, writer tests fail due the lack of a single-file multiple segment example json in dcmqi. Waiting for
- https://github.com/QIICR/dcmqi/pull/401
- https://github.com/QIICR/dcmqi/issues/400