### PR TITLE
First draft of speedup adding frames

### DIFF
--- a/pydicom_seg/writer.py
+++ b/pydicom_seg/writer.py
@@ -197,6 +197,7 @@ class MultiClassWriter:
                     data=frame_data.astype(np.uint8),
                     referenced_segment=segment,
                     referenced_images=slice_to_source_images[slice_idx],
+                    update_pixel_data=False,
                 )
 
                 frame_fg_item.FrameContentSequence = [pydicom.Dataset()]
@@ -214,6 +215,9 @@ class MultiClassWriter:
                     f"Skipped empty slices for segment {segment}: "
                     f'{", ".join([str(x) for x in skipped_slices])}'
                 )
+
+        # Update pixel data after adding all frames to increase speed
+        result.update_pixel_data()
 
         # Encode all frames into a bytearray
         if self._inplane_cropping or self._skip_empty_slices:


### PR DESCRIPTION
Creating a dataset with a lot of slices is very slow. For a volume of shape 512x512x350 and 5 different classes it takes about 2 mins for me. This small change reduces the time to below 10 seconds, which is less than 1/10 of the original time.

The original code recalculates and replaces the PixelData for every segment added. In my case, it is 350x5=1750 times, as it is slices times classes.

I speeded it up by doing the calculation of PixelData only once at the end. 
If you don't like the way I implemented it, do you have a better idea for avoiding replacing PixelData for every frame?