### PR TITLE
Replace poetry with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,5 @@ mypy = "^1.0.0"
 pre-commit = "^2.10.1"
 
 [build-system]
-requires = ["poetry>=1.0.5"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
We can replace poetry with [poetry-core](https://github.com/python-poetry/poetry-core) as the build backend so that we can use a more lightweight tool than poetry to build this package (such as [`build`](https://pypa-build.readthedocs.io/en/stable/)).